### PR TITLE
hotfix: restore Supabase fallbacks — unbreak production

### DIFF
--- a/solva/lib/supabase.ts
+++ b/solva/lib/supabase.ts
@@ -2,14 +2,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { createClient } from '@supabase/supabase-js'
 import { Platform } from 'react-native'
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
-
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Please set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY.'
-  )
-}
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL ?? 'https://qzyxcooctlahwhhixyiy.supabase.co'
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? 'sb_publishable_gvNlWZrANOGAqW4o7HquUw_uFGfDgCB'
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
## Emergency fix

The previous PR removed the hardcoded Supabase URL/anon key fallbacks in `lib/supabase.ts` and replaced them with a `throw new Error(...)` if env vars were missing. This breaks the Vercel deploy because `EXPO_PUBLIC_SUPABASE_URL` is not set as a Vercel environment variable — the app crashes at module load time.

This restores the original fallback behavior.

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4