### PR TITLE
hotfix: revert vercel.json rewrite to original SPA pattern

### DIFF
--- a/solva/vercel.json
+++ b/solva/vercel.json
@@ -4,7 +4,7 @@
   "framework": null,
   "installCommand": "npm install",
   "rewrites": [
-    { "source": "/((?!_expo|assets|static|favicon|manifest|robots|sitemap|.*\\.(js|css|map|png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|eot|json)).*)", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
The complex regex in vercel.json rewrites is not supported by Vercel. Reverts to the original `/(.*) → /index.html` which works correctly because Vercel serves static files before applying rewrites.

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4