### PR TITLE
fix(solva): fix 6 screens that crash or have critical bugs

### DIFF
--- a/solva/app/(app)/guarantee.tsx
+++ b/solva/app/(app)/guarantee.tsx
@@ -15,6 +15,7 @@ const FEATURES = [
 
 export default function GuaranteeScreen() {
   const insets = useSafeAreaInsets()
+  const { t } = useTranslation()
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>
       <View style={styles.header}>

--- a/solva/app/(app)/invoices.tsx
+++ b/solva/app/(app)/invoices.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons'
 
 export default function InvoicesScreen() {
   const insets = useSafeAreaInsets()
+  const { t } = useTranslation()
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>
       <View style={styles.header}>

--- a/solva/app/(app)/jobs/[id]/bid.tsx
+++ b/solva/app/(app)/jobs/[id]/bid.tsx
@@ -76,6 +76,12 @@ export default function NewBidScreen() {
 
       <ScrollView style={s.scroll} contentContainerStyle={s.content} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
 
+        {errorMsg ? (
+          <TouchableOpacity style={s.errorBox} onPress={() => setErrorMsg('')} activeOpacity={0.8}>
+            <Text style={s.errorText}>{errorMsg}</Text>
+          </TouchableOpacity>
+        ) : null}
+
         {/* Moneda badge */}
         <View style={s.currencyCard}>
           <View style={s.currencyIcon}>

--- a/solva/app/(app)/jobs/[id]/review.tsx
+++ b/solva/app/(app)/jobs/[id]/review.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   View, Text, StyleSheet, TouchableOpacity, TextInput, Alert,
   ActivityIndicator, ScrollView, Image
@@ -57,7 +57,7 @@ export default function ReviewScreen() {
     setLoaded(true)
   }
 
-  useState(() => { loadContract() })
+  useEffect(() => { loadContract() }, [id])
 
   async function pickPhotos(type: 'before' | 'after') {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()

--- a/solva/app/(app)/kyc.tsx
+++ b/solva/app/(app)/kyc.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useEffect, useState } from 'react'
 import {
-  View, Text, StyleSheet, TouchableOpacity, ScrollView,
+  Alert, View, Text, StyleSheet, TouchableOpacity, ScrollView,
   ActivityIndicator, Image
 } from 'react-native'
 import { router } from 'expo-router'
@@ -37,6 +37,7 @@ export default function KycScreen() {
   const [selfieUrl, setSelfieUrl] = useState('')
   const [uploading, setUploading] = useState('')
   const [saving, setSaving] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
 
   async function loadKyc() {
     const { data } = await supabase

--- a/solva/app/(app)/profile.tsx
+++ b/solva/app/(app)/profile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import {
-  View, Text, TextInput, TouchableOpacity, StyleSheet,
+  Alert, Platform, View, Text, TextInput, TouchableOpacity, StyleSheet,
   ActivityIndicator, ScrollView, Image
 } from 'react-native'
 import * as ImagePicker from 'expo-image-picker'
@@ -139,48 +139,6 @@ export default function ProfileScreen() {
   }, [])
 
 
-  // Detectar retorno de Stripe onboarding
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search)
-      if (params.get('stripe') === 'success') {
-        supabase.from('users')
-          .update({ stripe_onboarding_completed: true })
-          .eq('id', session!.user.id)
-          .then(() => {
-            refreshProfile()
-            setSuccessMsg('✅ Cuenta de cobro activada correctamente')
-            setTimeout(() => setSuccessMsg(''), 4000)
-          })
-        window.history.replaceState({}, '', window.location.pathname)
-      }
-    }
-  }, [])
-
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search)
-      if (params.get('stripe') === 'success') {
-        supabase.from('users').update({ stripe_onboarding_completed: true }).eq('id', session!.user.id).then(() => { refreshProfile(); })
-        setSuccessMsg('Cuenta de cobro activada')
-        setTimeout(() => setSuccessMsg(''), 4000)
-        window.history.replaceState({}, '', window.location.pathname)
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search)
-      if (params.get('stripe') === 'success') {
-        supabase.from('users').update({ stripe_onboarding_completed: true }).eq('id', session!.user.id).then(() => { refreshProfile() })
-        setSuccessMsg('Cuenta de cobro activada')
-        setTimeout(() => setSuccessMsg(''), 4000)
-        window.history.replaceState({}, '', window.location.pathname)
-      }
-    }
-  }, [])
   
   async function handleStripeConnect() {
     try {
@@ -220,13 +178,6 @@ export default function ProfileScreen() {
       onPress: () => router.push('/(app)/referrals'),
     },
     ...(profile?.role === 'pro' || profile?.role === 'company' ? [{
-      icon: 'construct-outline' as const,
-      label: 'Mis servicios',
-      badge: 'Nuevo',
-      badgeColor: '#059669',
-      badgeBg: '#D1FAE5',
-      onPress: () => router.push('/(app)/pro-services'),
-    }, {
       icon: 'construct-outline' as const,
       label: 'Mis servicios',
       badge: 'Nuevo',
@@ -341,7 +292,7 @@ export default function ProfileScreen() {
             <Text style={styles.profileEmail}>{profile?.email}</Text>
             <View style={styles.ratingRow}>
               <Ionicons name="star" size={14} color="#F59E0B" />
-              <Text style={styles.ratingText}>4.9</Text>
+              <Text style={styles.ratingText}>{profile?.avg_rating ? Number(profile.avg_rating).toFixed(1) : '-'}</Text>
               <Text style={styles.ratingLabel}>{t('profile.rating')}</Text>
             </View>
           </View>
@@ -495,7 +446,16 @@ export default function ProfileScreen() {
       {/* Logout */}
       <TouchableOpacity
         style={styles.logoutBtn}
-        onPress={async () => { if (typeof window !== 'undefined' && window.confirm('¿Cerrar sesión?')) await signOut() }}
+        onPress={() => {
+          if (Platform.OS === 'web') {
+            if (typeof window !== 'undefined' && window.confirm('¿Cerrar sesión?')) signOut()
+          } else {
+            Alert.alert('Cerrar sesión', '¿Estás seguro?', [
+              { text: 'Cancelar', style: 'cancel' },
+              { text: 'Cerrar sesión', style: 'destructive', onPress: () => signOut() },
+            ])
+          }
+        }}
         activeOpacity={0.8}
       >
         <Ionicons name="log-out-outline" size={18} color="#EF4444" />


### PR DESCRIPTION
## Summary

Fixes 6 screens that crash or have critical bugs on render:

- **guarantee.tsx** — crash: `t()` called without `useTranslation()`
- **invoices.tsx** — crash: same issue
- **kyc.tsx** — crash: `setErrorMsg` used without `useState`, `Alert` used without import
- **profile.tsx** — 3 duplicate Stripe useEffects removed (4→1), duplicate "Mis servicios" menu removed (2→1), hardcoded rating 4.9 replaced with real data, logout now uses Alert.alert on native
- **review.tsx** — `useState(() => { loadContract() })` replaced with proper `useEffect`
- **bid.tsx** — `errorMsg` was set on validation errors but never rendered in JSX

## Test plan
- [ ] Open Guarantee screen — should render without crash
- [ ] Open Invoices screen — should render without crash
- [ ] Open KYC screen — upload flow should work, validation errors visible
- [ ] Open Profile screen — no duplicate menu items, rating shows real data
- [ ] Open Review screen — contract loads correctly on mount
- [ ] Open Bid screen — validation errors now display visually

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4