### PR TITLE
fix: remove unsupported fields from supabase config.toml

### DIFF
--- a/solva/supabase/config.toml
+++ b/solva/supabase/config.toml
@@ -1,111 +1,52 @@
 
 [functions.create-payment-intent]
-enabled = true
 verify_jwt = true
 import_map = "./functions/create-payment-intent/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/create-payment-intent/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/create-payment-intent/*.html" ]
 
 [functions.release-payment]
-enabled = true
 verify_jwt = true
 import_map = "./functions/release-payment/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/release-payment/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/release-payment/*.html" ]
 
 [functions.create-subscription]
-enabled = true
 verify_jwt = true
 import_map = "./functions/create-subscription/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/create-subscription/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/create-subscription/*.html" ]
 
 [functions.ai-search]
-enabled = true
 verify_jwt = true
 import_map = "./functions/ai-search/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/ai-search/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/ai-search/*.html" ]
 
 [functions.verify-photos]
-enabled = true
 verify_jwt = true
 import_map = "./functions/verify-photos/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/verify-photos/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/verify-photos/*.html" ]
 
 [functions.create-mercadopago-payment]
-enabled = true
 verify_jwt = true
 import_map = "./functions/create-mercadopago-payment/deno.json"
-# Uncomment to specify a custom file path to the entrypoint.
-# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
-entrypoint = "./functions/create-mercadopago-payment/index.ts"
-# Specifies static files to be bundled with the function. Supports glob patterns.
-# For example, if you want to serve static HTML pages in your function:
-# static_files = [ "./functions/create-mercadopago-payment/*.html" ]
 
 [functions.mercadopago-webhook]
-enabled = true
-# Los webhooks de MercadoPago no envían JWT; la autenticación se hace vía HMAC en la función.
 verify_jwt = false
 import_map = "./functions/mercadopago-webhook/deno.json"
-entrypoint = "./functions/mercadopago-webhook/index.ts"
 
 [functions.stripe-webhook]
-enabled = true
-# Los webhooks de Stripe no envían JWT; la autenticación se hace vía signature en la función.
 verify_jwt = false
 import_map = "./functions/stripe-webhook/deno.json"
-entrypoint = "./functions/stripe-webhook/index.ts"
 
 [functions.api-gateway]
-enabled = true
-# El api-gateway usa su propio esquema x-api-key; no usa JWT de Supabase Auth.
 verify_jwt = false
 import_map = "./functions/api-gateway/deno.json"
-entrypoint = "./functions/api-gateway/index.ts"
 
 [functions.create-stripe-account]
-enabled = true
 verify_jwt = true
 import_map = "./functions/create-stripe-account/deno.json"
-entrypoint = "./functions/create-stripe-account/index.ts"
 
 [functions.generate-pro-content]
-enabled = true
 verify_jwt = true
 import_map = "./functions/generate-pro-content/deno.json"
-entrypoint = "./functions/generate-pro-content/index.ts"
 
 [functions.send-email]
-enabled = true
 verify_jwt = true
 import_map = "./functions/send-email/deno.json"
-entrypoint = "./functions/send-email/index.ts"
 
 [functions.send-notification]
-enabled = true
 verify_jwt = true
 import_map = "./functions/send-notification/deno.json"
-entrypoint = "./functions/send-notification/index.ts"


### PR DESCRIPTION
Remove `enabled` and `entrypoint` fields from config.toml — not supported by Supabase CLI. Only `verify_jwt` and `import_map` are valid.

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4