### PR TITLE
fix(solva): reset password, dispute email, countries, notifications type

### DIFF
--- a/solva/app/(app)/settings-country.tsx
+++ b/solva/app/(app)/settings-country.tsx
@@ -9,13 +9,19 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../lib/AuthContext'
 
 const COUNTRIES = [
-  { code: 'ES', flag: '🇪🇸', name: 'España', currency: 'EUR', language: 'es-ES' },
+  { code: 'ES', flag: '🇪🇸', name: 'España', currency: 'EUR', language: 'es' },
+  { code: 'FR', flag: '🇫🇷', name: 'France', currency: 'EUR', language: 'fr' },
+  { code: 'BE', flag: '🇧🇪', name: 'Belgique', currency: 'EUR', language: 'fr' },
+  { code: 'NL', flag: '🇳🇱', name: 'Nederland', currency: 'EUR', language: 'nl' },
+  { code: 'DE', flag: '🇩🇪', name: 'Deutschland', currency: 'EUR', language: 'de' },
+  { code: 'PT', flag: '🇵🇹', name: 'Portugal', currency: 'EUR', language: 'pt' },
+  { code: 'IT', flag: '🇮🇹', name: 'Italia', currency: 'EUR', language: 'it' },
+  { code: 'GB', flag: '🇬🇧', name: 'United Kingdom', currency: 'GBP', language: 'en' },
   { code: 'MX', flag: '🇲🇽', name: 'México', currency: 'MXN', language: 'es' },
   { code: 'CO', flag: '🇨🇴', name: 'Colombia', currency: 'COP', language: 'es' },
   { code: 'AR', flag: '🇦🇷', name: 'Argentina', currency: 'ARS', language: 'es' },
   { code: 'CL', flag: '🇨🇱', name: 'Chile', currency: 'CLP', language: 'es' },
-  { code: 'BR', flag: '🇧🇷', name: 'Brasil', currency: 'BRL', language: 'pt-BR' },
-  { code: 'FR', flag: '🇫🇷', name: 'Francia', currency: 'EUR', language: 'es' },
+  { code: 'BR', flag: '🇧🇷', name: 'Brasil', currency: 'BRL', language: 'pt' },
 ]
 
 export default function CountryScreen() {

--- a/solva/app/(auth)/login.tsx
+++ b/solva/app/(auth)/login.tsx
@@ -28,8 +28,11 @@ export default function LoginScreen() {
     setResetLoading(true)
     setResetMsg('')
     try {
-      const res = await supabase.functions.invoke('reset-password', { body: { email: resetEmail.trim().toLowerCase() } })
-      if (res.error) throw res.error
+      const { error } = await supabase.auth.resetPasswordForEmail(
+        resetEmail.trim().toLowerCase(),
+        { redirectTo: 'https://www.getsolva.co/auth/callback' }
+      )
+      if (error) throw error
       setResetMsg('✅ Email enviado. Revisa tu bandeja de entrada.')
     } catch (err: any) {
       setResetMsg('❌ ' + (err.message ?? 'Error al enviar email'))

--- a/solva/supabase/functions/send-email/index.ts
+++ b/solva/supabase/functions/send-email/index.ts
@@ -49,6 +49,18 @@ const TEMPLATES: Record<string, (data: any) => { subject: string; html: string }
         <a href="https://www.getsolva.co" style="display:inline-block;margin-top:16px;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver historial →</a>
       </div>`,
   }),
+  dispute_opened: (d) => ({
+    subject: `⚠️ Disputa abierta — "${d.jobTitle}"`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#DC2626">Se ha abierto una disputa</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Se ha abierto una disputa para el trabajo <b>"${d.jobTitle}"</b>.</p>
+        <p><b>Motivo:</b> ${d.reason}</p>
+        <p style="color:#555">El pago queda bloqueado hasta que se resuelva. Nuestro equipo revisará el caso en 48-72h hábiles.</p>
+        <a href="https://www.getsolva.co/(app)/jobs/${d.jobId}/dispute" style="display:inline-block;margin-top:16px;background:#DC2626;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver disputa →</a>
+      </div>`,
+  }),
 }
 
 Deno.serve(async (req) => {

--- a/solva/supabase/migrations/20260412200000_notifications_type_column.sql
+++ b/solva/supabase/migrations/20260412200000_notifications_type_column.sql
@@ -1,0 +1,3 @@
+-- Add type column to notifications table
+-- Used by stripe-webhook to categorize notifications (payment_held, payment_failed, etc.)
+ALTER TABLE public.notifications ADD COLUMN IF NOT EXISTS type TEXT;


### PR DESCRIPTION
## Summary

Week 1 fixes — funcionalidad rota que impedía flujos completos:

- **Reset password**: `login.tsx` llamaba a edge function `reset-password` que no existía. Reemplazado con `supabase.auth.resetPasswordForEmail()` (built-in)
- **Email de disputa**: `dispute.tsx` invocaba template `dispute_opened` en `send-email` que no estaba definido. Template añadido
- **Países en settings**: solo había 7 países (faltaban BE, NL, DE, PT, IT, GB). Ahora los 13 países soportados. Language codes corregidos para coincidir con i18n
- **Notifications type**: `stripe-webhook` insertaba campo `type` en `notifications` que no existía. Migración añadida

## Test plan
- [ ] Probar "Olvidé mi contraseña" desde login — debe enviar email
- [ ] Abrir disputa — debe enviar email al otro usuario
- [ ] Settings → País y moneda — verificar que aparecen los 13 países
- [ ] Ejecutar migración: `ALTER TABLE public.notifications ADD COLUMN IF NOT EXISTS type TEXT;`

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4