### PR TITLE
fix: unify min password 8 chars, remove console.log, fix route

### DIFF
--- a/solva/app/(auth)/login.tsx
+++ b/solva/app/(auth)/login.tsx
@@ -100,7 +100,7 @@ export default function LoginScreen() {
       setErrorMsg('⏱ El link de confirmación ha caducado. Inicia sesión para recibir uno nuevo.')
     }
   }, [])
-  const canLogin = email.trim().length > 0 && password.length >= 6
+  const canLogin = email.trim().length > 0 && password.length >= 8
 
   return (
     <KeyboardAvoidingView

--- a/solva/app/(auth)/register.tsx
+++ b/solva/app/(auth)/register.tsx
@@ -80,7 +80,7 @@ export default function RegisterScreen() {
 
   const strength = passwordStrength(password)
   const selectedCountry = COUNTRIES.find(c => c.value === country)!
-  const canStep1 = fullName.trim().length > 0 && email.trim().length > 0 && password.length >= 6
+  const canStep1 = fullName.trim().length > 0 && email.trim().length > 0 && password.length >= 8
 
   async function handleRegister() {
     if (!acceptTerms) { setErrorMsg('Debes aceptar los términos para continuar.'); return }
@@ -105,7 +105,7 @@ export default function RegisterScreen() {
       if (error.message.includes('already registered') || error.message.includes('already exists')) {
         setErrorMsg('Este email ya está registrado. ¿Quieres iniciar sesión?')
       } else if (error.message.includes('password')) {
-        setErrorMsg('La contraseña debe tener al menos 6 caracteres.')
+        setErrorMsg('La contraseña debe tener al menos 8 caracteres.')
       } else {
         setErrorMsg(error.message)
       }
@@ -206,7 +206,7 @@ export default function RegisterScreen() {
                 style={styles.input}
                 value={password}
                 onChangeText={setPassword}
-                placeholder={t("auth.min6chars")}
+                placeholder={t("auth.min8chars")}
                 placeholderTextColor="#aaa"
                 secureTextEntry={!showPassword}
               />

--- a/solva/app/(auth)/reset-password.tsx
+++ b/solva/app/(auth)/reset-password.tsx
@@ -29,7 +29,7 @@ export default function ResetPasswordScreen() {
 
   async function handleReset() {
     if (password !== confirm) { setMsg('no_match'); return }
-    if (password.length < 6) { setMsg('too_short'); return }
+    if (password.length < 8) { setMsg('too_short'); return }
     setLoading(true)
     const { error } = await supabase.auth.updateUser({ password })
     setLoading(false)
@@ -81,7 +81,7 @@ export default function ResetPasswordScreen() {
             <Text style={styles.label}>{t('security.newPassword')}</Text>
             <View style={styles.inputRow}>
               <Ionicons name="lock-closed-outline" size={18} color="#888" />
-              <TextInput style={styles.input} value={password} onChangeText={setPassword} placeholder="Mínimo 6 caracteres" placeholderTextColor="#aaa" secureTextEntry={!showPwd} />
+              <TextInput style={styles.input} value={password} onChangeText={setPassword} placeholder={t('auth.min8chars')} placeholderTextColor="#aaa" secureTextEntry={!showPwd} />
               <TouchableOpacity onPress={() => setShowPwd(!showPwd)}>
                 <Ionicons name={showPwd ? 'eye-off-outline' : 'eye-outline'} size={18} color="#888" />
               </TouchableOpacity>

--- a/solva/app/auth/callback.tsx
+++ b/solva/app/auth/callback.tsx
@@ -27,22 +27,18 @@ export default function AuthCallback() {
           })
           if (!error && data.user) {
             if (type === 'recovery') {
-              router.replace('/reset-password')
+              router.replace('/(auth)/reset-password')
               return
             }
             // Verificar onboarding
-            console.log('user id:', data.user.id)
             const { data: profile } = await supabase
               .from('users')
               .select('onboarding_completed')
               .eq('id', data.user.id)
               .single()
-            console.log('profile:', JSON.stringify(profile))
             if (profile && !profile.onboarding_completed) {
-              console.log('→ onboarding')
               router.replace('/(app)/onboarding')
             } else {
-              console.log('→ home')
               router.replace('/(app)')
             }
             return


### PR DESCRIPTION
## Summary
- Minimum password length unified to 8 characters (was 6 in login/register/reset-password, 8 in settings-security)
- Remove 4 `console.log` debug statements from auth/callback.tsx
- Fix reset-password route: `/reset-password` → `/(auth)/reset-password`

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4