### PR TITLE
feat(solva): add cron jobs + Sentry error monitoring

### DIFF
--- a/solva/app.json
+++ b/solva/app.json
@@ -62,6 +62,7 @@
     },
     "plugins": [
       "./plugins/withNoGoogleServices",
+      "@sentry/react-native/expo",
       "expo-secure-store",
       "expo-localization",
       "expo-font",

--- a/solva/app/_layout.tsx
+++ b/solva/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Stack, router } from 'expo-router'
 import 'react-native-url-polyfill/auto'
+import { initSentry } from '../lib/sentry'
 import { initI18n } from '../lib/i18n'
 import { AuthProvider, useAuth } from '../lib/AuthContext'
 import * as Font from 'expo-font'
@@ -8,6 +9,9 @@ import { Ionicons } from '@expo/vector-icons'
 import * as SplashScreen from 'expo-splash-screen'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import PaymentProvider from '../components/PaymentProvider'
+
+// Initialize Sentry as early as possible
+initSentry()
 
 SplashScreen.preventAutoHideAsync()
 

--- a/solva/lib/sentry.ts
+++ b/solva/lib/sentry.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/react-native'
+import Constants from 'expo-constants'
+
+const SENTRY_DSN = process.env.EXPO_PUBLIC_SENTRY_DSN
+
+export function initSentry() {
+  if (!SENTRY_DSN) {
+    console.warn('Sentry DSN not configured — error tracking disabled')
+    return
+  }
+
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: __DEV__ ? 'development' : 'production',
+    release: Constants.expoConfig?.version ?? '1.0.0',
+    dist: Constants.expoConfig?.android?.versionCode?.toString() ?? '1',
+    tracesSampleRate: __DEV__ ? 1.0 : 0.2,
+    enableAutoSessionTracking: true,
+    attachScreenshot: true,
+    // Don't send in dev unless explicitly configured
+    enabled: !__DEV__ || !!SENTRY_DSN,
+  })
+}
+
+export { Sentry }

--- a/solva/package.json
+++ b/solva/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/react-native": "^6.5.0",
     "@stripe/react-stripe-js": "^5.6.1",
     "@stripe/stripe-js": "^8.10.0",
     "@stripe/stripe-react-native": "^0.59.2",

--- a/solva/supabase/migrations/20260412300000_cron_jobs.sql
+++ b/solva/supabase/migrations/20260412300000_cron_jobs.sql
@@ -1,0 +1,58 @@
+-- Enable pg_cron extension (available on Supabase by default)
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Grant usage to postgres role
+GRANT USAGE ON SCHEMA cron TO postgres;
+
+-- ========================================
+-- 1. Reset API key daily request counters
+-- Runs at midnight UTC every day
+-- ========================================
+SELECT cron.schedule(
+  'reset-api-requests-daily',
+  '0 0 * * *',
+  $$UPDATE public.api_keys SET requests_today = 0 WHERE requests_today > 0$$
+);
+
+-- ========================================
+-- 2. Expire trials that have ended
+-- Runs every hour — checks trial_ends_at
+-- ========================================
+SELECT cron.schedule(
+  'expire-trials-hourly',
+  '0 * * * *',
+  $$UPDATE public.subscriptions
+    SET status = 'expired', cancel_at_period_end = true
+    WHERE status = 'trialing'
+    AND trial_ends_at IS NOT NULL
+    AND trial_ends_at < NOW()$$
+);
+
+-- ========================================
+-- 3. Clean up expired push tokens
+-- Runs weekly on Sunday at 3 AM UTC
+-- Removes tokens older than 90 days (likely stale)
+-- ========================================
+SELECT cron.schedule(
+  'cleanup-push-tokens-weekly',
+  '0 3 * * 0',
+  $$DELETE FROM public.push_tokens
+    WHERE created_at < NOW() - INTERVAL '90 days'$$
+);
+
+-- ========================================
+-- 4. Auto-close stale disputes
+-- Runs daily at 6 AM UTC
+-- Disputes open for more than 30 days without resolution
+-- get marked as closed with a note
+-- ========================================
+SELECT cron.schedule(
+  'close-stale-disputes-daily',
+  '0 6 * * *',
+  $$UPDATE public.disputes
+    SET status = 'closed',
+        resolution_note = 'Cerrada automáticamente por inactividad tras 30 días.',
+        resolved_at = NOW()
+    WHERE status IN ('open', 'under_review')
+    AND created_at < NOW() - INTERVAL '30 days'$$
+);


### PR DESCRIPTION
## Summary

### Cron jobs (Supabase pg_cron)
4 scheduled tasks that were missing:
- **reset-api-requests-daily** (midnight UTC) — resets `api_keys.requests_today`
- **expire-trials-hourly** — expires trialing subscriptions past `trial_ends_at`
- **cleanup-push-tokens-weekly** (Sunday 3AM) — removes tokens older than 90 days
- **close-stale-disputes-daily** (6AM) — auto-closes disputes open >30 days

### Sentry error monitoring
- `@sentry/react-native` + expo plugin
- `lib/sentry.ts` — initializes from `EXPO_PUBLIC_SENTRY_DSN` env var
- Gracefully disabled if DSN not set (no crash, just console.warn)
- 20% trace sampling in production, 100% in dev

### Setup required
1. **Sentry**: Create project at sentry.io, add `EXPO_PUBLIC_SENTRY_DSN` to `.env` and `eas.json`
2. **Cron**: Paste migration SQL in Supabase SQL Editor
3. Run `npm install` to add `@sentry/react-native`

## Test plan
- [ ] Verify app loads without Sentry DSN (should warn but not crash)
- [ ] Configure Sentry DSN and verify errors appear in dashboard
- [ ] Apply cron migration and verify jobs appear in `cron.job` table

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4