### PR TITLE
feat(solva): add 6 transactional email templates

### DIFF
--- a/solva/app/(app)/admin.tsx
+++ b/solva/app/(app)/admin.tsx
@@ -70,6 +70,17 @@ export default function AdminScreen() {
     if (status === 'approved') {
       await supabase.from('users').update({ is_verified: true }).eq('id', userId)
     }
+    // Send KYC result email
+    const { data: kycUser } = await supabase.from('users').select('email, full_name').eq('id', userId).maybeSingle()
+    if (kycUser?.email) {
+      supabase.functions.invoke('send-email', {
+        body: {
+          to: kycUser.email,
+          template: status === 'approved' ? 'kyc_approved' : 'kyc_rejected',
+          data: { userName: kycUser.full_name ?? 'Usuario' },
+        },
+      }).catch(() => {})
+    }
     await loadAll()
     setActing(null)
   }

--- a/solva/app/(app)/jobs/new.tsx
+++ b/solva/app/(app)/jobs/new.tsx
@@ -90,6 +90,16 @@ export default function NewJobScreen() {
     if (error) {
       setErrorMsg('Error al publicar: ' + error.message)
     } else {
+      // Send job_posted email
+      if (data && session?.user?.email) {
+        supabase.functions.invoke('send-email', {
+          body: {
+            to: session.user.email,
+            template: 'job_posted',
+            data: { userName: profile?.full_name ?? 'Usuario', jobTitle: title, jobId: data.id },
+          },
+        }).catch(() => {})
+      }
       router.replace('/(app)/jobs')
     }
   }

--- a/solva/lib/AuthContext.tsx
+++ b/solva/lib/AuthContext.tsx
@@ -77,6 +77,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if ((newProfile as UserProfile).language) {
         changeLanguage((newProfile as UserProfile).language)
       }
+      // Send welcome email for new users
+      supabase.functions.invoke('send-email', {
+        body: {
+          to: newRow.email,
+          template: 'welcome',
+          data: { userName: newRow.full_name },
+        },
+      }).catch(() => {})
     }
   }
 

--- a/solva/supabase/functions/send-email/index.ts
+++ b/solva/supabase/functions/send-email/index.ts
@@ -61,6 +61,80 @@ const TEMPLATES: Record<string, (data: any) => { subject: string; html: string }
         <a href="https://www.getsolva.co/(app)/jobs/${d.jobId}/dispute" style="display:inline-block;margin-top:16px;background:#DC2626;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver disputa →</a>
       </div>`,
   }),
+  welcome: (d) => ({
+    subject: `🎉 Bienvenido a Solva, ${d.userName}`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#2563EB">¡Bienvenido a Solva!</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Gracias por unirte a Solva, la plataforma que conecta clientes con profesionales verificados para servicios del hogar.</p>
+        <p>Esto es lo que puedes hacer ahora:</p>
+        <ul style="color:#555;line-height:24px">
+          <li>🔍 <b>Buscar profesionales</b> cerca de ti</li>
+          <li>📝 <b>Publicar un trabajo</b> y recibir ofertas</li>
+          <li>🛡️ <b>Pagar con escrow</b> — tu dinero está protegido</li>
+        </ul>
+        <a href="https://www.getsolva.co" style="display:inline-block;margin-top:16px;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Empezar →</a>
+        <p style="color:#aaa;font-size:12px;margin-top:24px">¿Necesitas ayuda? Responde a este email o visita nuestro centro de ayuda.</p>
+      </div>`,
+  }),
+  job_posted: (d) => ({
+    subject: `📝 Tu trabajo "${d.jobTitle}" ha sido publicado`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#2563EB">Trabajo publicado</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Tu trabajo <b>"${d.jobTitle}"</b> ya está visible para los profesionales de tu zona.</p>
+        <p style="color:#555">Normalmente recibirás las primeras ofertas en menos de 24 horas. Te notificaremos por email y push cada vez que un profesional envíe una propuesta.</p>
+        <a href="https://www.getsolva.co/(app)/jobs/${d.jobId}" style="display:inline-block;margin-top:16px;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver mi trabajo →</a>
+      </div>`,
+  }),
+  payment_held: (d) => ({
+    subject: `🔒 Pago retenido en escrow — ${d.amount} ${d.currency}`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#2563EB">Pago en escrow</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Tu pago de <b>${d.amount} ${d.currency}</b> para el trabajo <b>"${d.jobTitle}"</b> ha sido procesado y está retenido de forma segura.</p>
+        <p style="color:#555">El dinero se liberará al profesional cuando confirmes que el trabajo está completado.</p>
+        <a href="https://www.getsolva.co/(app)/jobs/${d.jobId}/payment" style="display:inline-block;margin-top:16px;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver estado del pago →</a>
+      </div>`,
+  }),
+  kyc_approved: (d) => ({
+    subject: `✅ Identidad verificada — ya eres un profesional de confianza`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#059669">¡Verificación completada!</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Tu identidad ha sido verificada correctamente. Ahora tienes el badge de verificado en tu perfil.</p>
+        <p style="color:#555">Los profesionales verificados reciben hasta un 40% más de contratos. ¡Enhorabuena!</p>
+        <a href="https://www.getsolva.co/(app)/profile" style="display:inline-block;margin-top:16px;background:#059669;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Ver mi perfil →</a>
+      </div>`,
+  }),
+  kyc_rejected: (d) => ({
+    subject: `❌ Verificación rechazada — acción requerida`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#DC2626">Verificación rechazada</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Tu verificación de identidad ha sido rechazada.</p>
+        ${d.reason ? `<p><b>Motivo:</b> ${d.reason}</p>` : ''}
+        <p style="color:#555">Puedes volver a intentarlo con documentos más claros. Asegúrate de que las fotos sean legibles y la selfie coincida con el documento.</p>
+        <a href="https://www.getsolva.co/(app)/kyc" style="display:inline-block;margin-top:16px;background:#DC2626;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Reintentar verificación →</a>
+      </div>`,
+  }),
+  trial_expiring: (d) => ({
+    subject: `⏰ Tu prueba Pro expira en ${d.daysLeft} día${d.daysLeft === 1 ? '' : 's'}`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:32px">
+        <h1 style="color:#D97706">Tu prueba Pro está por terminar</h1>
+        <p>Hola <b>${d.userName}</b>,</p>
+        <p>Tu período de prueba de <b>Solva Pro</b> expira en <b>${d.daysLeft} día${d.daysLeft === 1 ? '' : 's'}</b>.</p>
+        <p style="color:#555">Con Pro tienes bids ilimitados, comisión reducida al 5%, y posición preferente en búsquedas. Un solo contrato extra al mes cubre la suscripción.</p>
+        <a href="https://www.getsolva.co/(app)/subscription" style="display:inline-block;margin-top:16px;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">Activar Pro →</a>
+        <p style="color:#aaa;font-size:12px;margin-top:24px">Si no activas Pro, volverás automáticamente al plan gratuito.</p>
+      </div>`,
+  }),
 }
 
 Deno.serve(async (req) => {


### PR DESCRIPTION
## Summary

6 new transactional email templates + integration into app flows.

### New templates
| Template | When | Sent to |
|---|---|---|
| `welcome` | New user signs up | User |
| `job_posted` | Client publishes a job | Client |
| `payment_held` | Escrow payment processed | Client |
| `kyc_approved` | Admin approves identity | Pro |
| `kyc_rejected` | Admin rejects identity | Pro |
| `trial_expiring` | Pro trial about to end | Pro |

### Integration points
- **AuthContext.tsx** → `welcome` on new profile creation
- **jobs/new.tsx** → `job_posted` after successful publish
- **admin.tsx** → `kyc_approved` / `kyc_rejected` on KYC review

`payment_held` and `trial_expiring` are defined but not yet wired (payment_held should come from stripe-webhook, trial_expiring from a cron job — future PR).

Total: 11 email templates (was 5).

## Test plan
- [ ] Register new user → receive welcome email
- [ ] Post a job → receive job_posted email
- [ ] Admin approves KYC → user receives kyc_approved email
- [ ] Admin rejects KYC → user receives kyc_rejected email

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4