### PR TITLE
feat(solva): interactive jobs map (search page)

### DIFF
--- a/solva/app/(app)/search.tsx
+++ b/solva/app/(app)/search.tsx
@@ -10,6 +10,7 @@ import { useProfile } from '../../hooks/useProfile'
 import { useLocation } from '../../hooks/useLocation'
 import { Ionicons } from '@expo/vector-icons'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import JobsMap from '../../components/JobsMap'
 
 const CATEGORIES = [
   { labelKey: 'search.catAll',         icon: '✨', value: null },
@@ -321,32 +322,51 @@ export default function SearchScreen() {
           contentContainerStyle={filteredResults.length === 0 ? styles.emptyContainer : styles.list}
           showsVerticalScrollIndicator={false}
           ListHeaderComponent={
-            parsed ? (
-              <View style={styles.parsedCard}>
-                <View style={styles.parsedHeader}>
-                  <Ionicons name="sparkles" size={16} color="#2563EB" />
-                  <Text style={styles.parsedSummary}>{parsed.summary}</Text>
+            <>
+              {/* Map */}
+              {filteredResults.some(j => j.latitude && j.longitude) && (
+                <View style={{ marginBottom: 12 }}>
+                  <JobsMap
+                    jobs={filteredResults.filter((j: any) => j.latitude && j.longitude).map((j: any) => ({
+                      id: j.id, title: j.title, category: j.category,
+                      latitude: j.latitude, longitude: j.longitude,
+                      budget_min: j.budget_min, budget_max: j.budget_max,
+                      currency: j.currency, city: j.city,
+                    }))}
+                    userLat={coords?.latitude}
+                    userLng={coords?.longitude}
+                    onJobPress={(id) => router.push(`/(app)/jobs/${id}`)}
+                    height={220}
+                  />
                 </View>
-                {parsed.suggestions?.length > 0 && (
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                    <View style={styles.suggestionsRow}>
-                      {parsed.suggestions.map((sug: string, i: number) => (
-                        <TouchableOpacity
-                          key={i}
-                          style={styles.suggestionChip}
-                          onPress={() => { setQuery(sug); handleSearch(sug) }}
-                        >
-                          <Text style={styles.suggestionText}>{sug}</Text>
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  </ScrollView>
-                )}
-                <Text style={styles.resultCount}>
-                  {filteredResults.length} resultado{filteredResults.length !== 1 ? 's' : ''}
-                </Text>
-              </View>
-            ) : null
+              )}
+              {parsed ? (
+                <View style={styles.parsedCard}>
+                  <View style={styles.parsedHeader}>
+                    <Ionicons name="sparkles" size={16} color="#2563EB" />
+                    <Text style={styles.parsedSummary}>{parsed.summary}</Text>
+                  </View>
+                  {parsed.suggestions?.length > 0 && (
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                      <View style={styles.suggestionsRow}>
+                        {parsed.suggestions.map((sug: string, i: number) => (
+                          <TouchableOpacity
+                            key={i}
+                            style={styles.suggestionChip}
+                            onPress={() => { setQuery(sug); handleSearch(sug) }}
+                          >
+                            <Text style={styles.suggestionText}>{sug}</Text>
+                          </TouchableOpacity>
+                        ))}
+                      </View>
+                    </ScrollView>
+                  )}
+                  <Text style={styles.resultCount}>
+                    {filteredResults.length} resultado{filteredResults.length !== 1 ? 's' : ''}
+                  </Text>
+                </View>
+              ) : null}
+            </>
           }
           ListEmptyComponent={
             <View style={styles.empty}>

--- a/solva/components/JobsMap.tsx
+++ b/solva/components/JobsMap.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react'
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import MapView, { Marker, Region } from 'react-native-maps'
+import { Ionicons } from '@expo/vector-icons'
+
+export interface MapJob {
+  id: string
+  title: string
+  category: string
+  latitude: number
+  longitude: number
+  budget_min: number | null
+  budget_max: number | null
+  currency: string
+  city: string | null
+}
+
+interface JobsMapProps {
+  jobs: MapJob[]
+  userLat?: number | null
+  userLng?: number | null
+  onJobPress?: (jobId: string) => void
+  height?: number
+}
+
+const CATEGORY_COLOR: Record<string, string> = {
+  cleaning: '#059669', plumbing: '#2563EB', electrical: '#D97706',
+  painting: '#7C3AED', moving: '#DC2626', gardening: '#16A34A',
+  carpentry: '#92400E', tech: '#0891B2', design: '#DB2777', other: '#6B7280',
+}
+
+export default function JobsMap({ jobs, userLat, userLng, onJobPress, height = 300 }: JobsMapProps) {
+  const mapRef = useRef<MapView>(null)
+
+  const initialRegion: Region = {
+    latitude: userLat ?? jobs[0]?.latitude ?? 40.4168,
+    longitude: userLng ?? jobs[0]?.longitude ?? -3.7038,
+    latitudeDelta: 0.15,
+    longitudeDelta: 0.15,
+  }
+
+  useEffect(() => {
+    if (mapRef.current && jobs.length > 0) {
+      const coords = jobs.map(j => ({ latitude: j.latitude, longitude: j.longitude }))
+      if (userLat && userLng) coords.push({ latitude: userLat, longitude: userLng })
+      mapRef.current.fitToCoordinates(coords, {
+        edgePadding: { top: 50, right: 50, bottom: 50, left: 50 },
+        animated: true,
+      })
+    }
+  }, [jobs.length])
+
+  if (jobs.length === 0) {
+    return (
+      <View style={[styles.empty, { height }]}>
+        <Ionicons name="map-outline" size={32} color="#ccc" />
+        <Text style={styles.emptyText}>Sin trabajos con ubicación</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={[styles.container, { height }]}>
+      <MapView
+        ref={mapRef}
+        style={StyleSheet.absoluteFillObject}
+        initialRegion={initialRegion}
+        showsUserLocation
+        showsMyLocationButton
+      >
+        {jobs.map(job => (
+          <Marker
+            key={job.id}
+            coordinate={{ latitude: job.latitude, longitude: job.longitude }}
+            title={job.title}
+            description={job.city ?? undefined}
+            pinColor={CATEGORY_COLOR[job.category] ?? '#6B7280'}
+            onCalloutPress={() => onJobPress?.(job.id)}
+          />
+        ))}
+      </MapView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { borderRadius: 16, overflow: 'hidden', backgroundColor: '#F6F7FB' },
+  empty: {
+    borderRadius: 16, backgroundColor: '#F6F7FB',
+    alignItems: 'center', justifyContent: 'center', gap: 8,
+    borderWidth: 1, borderColor: '#E5E7EB', borderStyle: 'dashed',
+  },
+  emptyText: { fontSize: 13, color: '#aaa' },
+})

--- a/solva/components/JobsMap.web.tsx
+++ b/solva/components/JobsMap.web.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+
+export interface MapJob {
+  id: string
+  title: string
+  category: string
+  latitude: number
+  longitude: number
+  budget_min: number | null
+  budget_max: number | null
+  currency: string
+  city: string | null
+}
+
+interface JobsMapProps {
+  jobs: MapJob[]
+  userLat?: number | null
+  userLng?: number | null
+  onJobPress?: (jobId: string) => void
+  height?: number
+}
+
+const CATEGORY_COLOR: Record<string, string> = {
+  cleaning: '#059669', plumbing: '#2563EB', electrical: '#D97706',
+  painting: '#7C3AED', moving: '#DC2626', gardening: '#16A34A',
+  carpentry: '#92400E', tech: '#0891B2', design: '#DB2777', other: '#6B7280',
+}
+
+export default function JobsMap({ jobs, userLat, userLng, onJobPress, height = 300 }: JobsMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null)
+  const leafletRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (!mapRef.current || typeof window === 'undefined') return
+
+    // Dynamically load Leaflet CSS
+    if (!document.getElementById('leaflet-css')) {
+      const link = document.createElement('link')
+      link.id = 'leaflet-css'
+      link.rel = 'stylesheet'
+      link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
+      document.head.appendChild(link)
+    }
+
+    // Dynamically load Leaflet JS
+    const loadLeaflet = (): Promise<any> => {
+      if ((window as any).L) return Promise.resolve((window as any).L)
+      return new Promise((resolve) => {
+        if (document.getElementById('leaflet-js')) {
+          const check = setInterval(() => {
+            if ((window as any).L) { clearInterval(check); resolve((window as any).L) }
+          }, 50)
+          return
+        }
+        const script = document.createElement('script')
+        script.id = 'leaflet-js'
+        script.src = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'
+        script.onload = () => resolve((window as any).L)
+        document.head.appendChild(script)
+      })
+    }
+
+    let map: any = null
+
+    loadLeaflet().then((L) => {
+      if (!mapRef.current) return
+
+      const centerLat = userLat ?? jobs[0]?.latitude ?? 40.4168
+      const centerLng = userLng ?? jobs[0]?.longitude ?? -3.7038
+
+      // Clean up previous map
+      if (leafletRef.current) {
+        leafletRef.current.remove()
+        leafletRef.current = null
+      }
+
+      map = L.map(mapRef.current).setView([centerLat, centerLng], 12)
+      leafletRef.current = map
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap',
+        maxZoom: 18,
+      }).addTo(map)
+
+      // User location marker
+      if (userLat && userLng) {
+        L.circleMarker([userLat, userLng], {
+          radius: 8, color: '#2563EB', fillColor: '#2563EB',
+          fillOpacity: 1, weight: 2,
+        }).addTo(map).bindPopup('Tu ubicación')
+      }
+
+      // Job markers
+      const bounds: [number, number][] = []
+      jobs.forEach(job => {
+        const color = CATEGORY_COLOR[job.category] ?? '#6B7280'
+        const budget = job.budget_min || job.budget_max
+          ? `${job.budget_min ?? '?'} – ${job.budget_max ?? '?'} ${job.currency}`
+          : 'A negociar'
+
+        const marker = L.circleMarker([job.latitude, job.longitude], {
+          radius: 10, color, fillColor: color,
+          fillOpacity: 0.8, weight: 2,
+        }).addTo(map)
+
+        marker.bindPopup(`
+          <div style="font-family:sans-serif;min-width:160px">
+            <strong style="font-size:13px">${job.title}</strong><br>
+            <span style="font-size:11px;color:#666">${job.city ?? ''}</span><br>
+            <span style="font-size:12px;font-weight:700;color:${color}">${budget}</span>
+          </div>
+        `)
+
+        marker.on('click', () => onJobPress?.(job.id))
+        bounds.push([job.latitude, job.longitude])
+      })
+
+      if (userLat && userLng) bounds.push([userLat, userLng])
+      if (bounds.length > 1) {
+        map.fitBounds(bounds, { padding: [30, 30] })
+      }
+    })
+
+    return () => {
+      if (leafletRef.current) {
+        leafletRef.current.remove()
+        leafletRef.current = null
+      }
+    }
+  }, [jobs.length, userLat, userLng])
+
+  if (jobs.length === 0) {
+    return (
+      <View style={[styles.empty, { height }]}>
+        <Ionicons name="map-outline" size={32} color="#ccc" />
+        <Text style={styles.emptyText}>Sin trabajos con ubicación</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={[styles.container, { height }]}>
+      {/* @ts-expect-error — div is valid on web */}
+      <div ref={mapRef} style={{ width: '100%', height: '100%' }} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { borderRadius: 16, overflow: 'hidden', backgroundColor: '#F6F7FB' },
+  empty: {
+    borderRadius: 16, backgroundColor: '#F6F7FB',
+    alignItems: 'center', justifyContent: 'center', gap: 8,
+    borderWidth: 1, borderColor: '#E5E7EB', borderStyle: 'dashed',
+  },
+  emptyText: { fontSize: 13, color: '#aaa' },
+})

--- a/solva/package.json
+++ b/solva/package.json
@@ -39,6 +39,7 @@
     "react-i18next": "^16.5.8",
     "react-native": "0.83.4",
     "react-native-gesture-handler": "~2.30.0",
+    "react-native-maps": "1.20.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",


### PR DESCRIPTION
## Summary

Interactive map showing jobs with location on the search results page.

### Components
- **JobsMap.tsx** (native): `react-native-maps` with colored markers per category, user location dot, auto-fit bounds
- **JobsMap.web.tsx** (web): Leaflet with OpenStreetMap tiles (free, no API key), circle markers with popups showing job title/budget

### Integration
- **search.tsx**: map renders above job list results when at least one job has lat/lng coordinates. Tapping a marker navigates to job detail.

### How it works
- Metro resolves `.web.tsx` for web and `.tsx` for native
- Web: Leaflet loaded dynamically (no bundle impact if map not used)
- Native: `react-native-maps` uses Apple Maps (iOS) / Google Maps (Android)
- Empty state when no jobs have coordinates

## Test plan
- [ ] Search for jobs on web → map appears with markers above results
- [ ] Click a marker popup → navigates to job detail
- [ ] Verify map doesn't appear when no jobs have coordinates
- [ ] Run `npm install` for react-native-maps dependency

https://claude.ai/code/session_01Me3aM5s85QY9PuRJp3Lct4